### PR TITLE
Suggest potential approach to highlighting markers on mouseover

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,9 @@
         $.getJSON("data/places-newtable.geojson", function (data) {
             drawPlaces(data);
         });
+        
+        // An empty layerGroup to store your clicked feature.
+        var selectedPlace = L.layerGroup([],).addTo(map)
 
         function drawPlaces(data) {
             // var popup = (data.features[0].properties.nameascii);
@@ -83,18 +86,24 @@
                     });
                     layer.openTooltip();
                 });
-                // create mouseover event
-                // not working: console says layer.setStyle is not a function
-                // is this because i am using a custom icon for markers?
-                /*layer.on('mouseover', function () {
-                    layer.setStyle({
-                        color: '#DAFF22'
-                        , weight: 4
-                    });
-                });*/
+                
+                // on mouseover, get the coordinates of the selected feature and use them to create a marker that will be added to selectedPlace LayerGroup.
+                layer.on('mouseover', function (e) {
+                    var selectedFeatureCoordinates = e.target.getLatLng();                   
+                    selectedPlaceMarker = L.marker([selectedFeatureCoordinates.lat, selectedFeatureCoordinates.lng], {
+                        icon: L.icon({
+                            iconUrl: 'images/audio-color.png', // Since this is  PNG, you'll need to make a version of your icon that is the color you want.
+                            iconSize: [30, 30],
+                            iconAnchor: [15, 15],
+                            popupAnchor: [0, 0]
+                        })
+                    })
+                    selectedPlace.addLayer(selectedPlaceMarker) // add the marker to the selectedPlace LayerGroup
+                });
                 layer.on('mouseout', function () {
                     layer.unbindTooltip();
                     layer.closeTooltip();
+                    selectedPlace.clearLayers() // On mouseout, clear the selectedPlace LayerGroup
                 });
             });
             // add marker cluster code here


### PR DESCRIPTION
Just an idea of how you could approach this issue. What happens here is when your map initially loads a LayerGroup, `selectedPlaces`, is created and added to the map. This layer has no layers so nothing from this LayerGroup will show up on the map. However, it gives you a container into which you can add and remove layers. On the mouseover event, you'll get the the coordinates of the feature you've moused over and use them to create a marker. You then add the marker to the LayerGroup you added earlier. When you mouseout, you can run the `.clearLayers()` method to clear out `selectedPlace`.

I'll admit, the interaction is still a little awkward here so there may be a better way, but hopefully this will get you steered in the right direction!